### PR TITLE
Update JmxTransformer.java

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -401,13 +401,13 @@ public class JmxTransformer implements WatchedCallback {
 		if ((server.getCronExpression() != null) && CronExpression.isValidExpression(server.getCronExpression())) {
 			trigger = new CronTrigger();
 			((CronTrigger) trigger).setCronExpression(server.getCronExpression());
-			trigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.currentTimeMillis()));
+			trigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.currentTimeMillis()) + "-" + RandomStringUtils.randomNumeric(10));
 			trigger.setStartTime(computeSpreadStartDate(configuration.getRunPeriod()));
 		} else {
 			int runPeriod = configuration.getRunPeriod();
 			if (server.getRunPeriodSeconds() != null) runPeriod = server.getRunPeriodSeconds();
 			Trigger minuteTrigger = TriggerUtils.makeSecondlyTrigger(runPeriod);
-			minuteTrigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.currentTimeMillis()));
+			minuteTrigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.currentTimeMillis()) + "-" + RandomStringUtils.randomNumeric(10));
 			minuteTrigger.setStartTime(computeSpreadStartDate(runPeriod));
 
 			trigger = minuteTrigger;


### PR DESCRIPTION
To fix ObjectAlreadyExists Exception which states unable to store trigger with 'hostname:port-time' and 'group: GroupName' as one already exists with this identification.
A fix was already published for the Job name but was not updated to Trigger name, which caused the issue